### PR TITLE
Adding tabindex=0 to prev and next buttons so they can gain keyboard …

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -90,6 +90,7 @@ export default {
           ],
           attrs: {
             role: 'button',
+            tabindex: 0,
           },
           on: {
             click,


### PR DESCRIPTION
Fixes virtual-peaker/product-vp#986 Adding tabindex=0 so that the previous and next buttons can be focused with the keyboard. 